### PR TITLE
Add missing include

### DIFF
--- a/test.c
+++ b/test.c
@@ -15,6 +15,7 @@
 #include <fcntl.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 void	doprint(int out, char **str, int line)
 {


### PR DESCRIPTION
Hello,
There are some errors when compiling with my Get_Next_Line because unistd.h is missing in test.c.
Make complains that the close function is not defined.
Here is a small fix for the problem!